### PR TITLE
fix: load menu icons when menu opens instead of loading them when scrolling in the menu

### DIFF
--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -10,7 +10,7 @@ const Footer = () => {
 
     return (
         <footer className="py-4 text-sm text-slate-400 border-t border-slate-200 dark:border-slate-600">
-            <p className="px-4 max-w-3xl mx-auto">{randomQuote}</p>
+            <p className="px-4 max-w-2xl mx-auto">{randomQuote}</p>
         </footer>
     );
 };

--- a/components/menu/menu.jsx
+++ b/components/menu/menu.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
     KBarProvider,
     KBarPortal,
@@ -10,9 +10,9 @@ import {
 } from 'kbar';
 import { useRouter } from 'next/router';
 import MenuButton from './menuButton';
+import MenuIcon from './menuIcon';
 import { useLocalStorageValue } from '@react-hookz/web';
 import { social } from '@/utils/social';
-import Image from 'next/image';
 
 const Menu = ({ children }) => {
     const [theme, setTheme, removeTheme] = useLocalStorageValue(
@@ -37,19 +37,8 @@ const Menu = ({ children }) => {
         id,
         name,
         keywords: id,
-        icon: forwardRef(function renderIcon(props, ref) {
-            return (
-                <Image
-                    {...props}
-                    src={`/social/${id}.svg`}
-                    lazyRoot={ref}
-                    width={16}
-                    height={16}
-                    quality={100}
-                    alt={id}
-                />
-            );
-        }),
+        iconSource: `/social/${id}.svg`,
+        iconDescription: `${id} icon`,
         section: 'Social',
         perform: () => window.open(url, '_blank'),
     }));
@@ -156,9 +145,7 @@ function RenderResults() {
             items={results}
             onRender={({ item, active }) => {
                 return typeof item === 'string' ? (
-                    <div className="text-sm px-4 py-2 text-slate-400">
-                        {item}
-                    </div>
+                    <div className="text-sm px-4 py-2 text-blue">{item}</div>
                 ) : (
                     <div
                         ref={lazyRootRef}
@@ -168,9 +155,13 @@ function RenderResults() {
                                 : 'bg-beige dark:bg-slate-900'
                         }`}
                     >
-                        {item.icon && (
+                        {item.iconSource && (
                             <div className="mr-3 flex">
-                                <item.icon lazyRoot={lazyRootRef} />
+                                <MenuIcon
+                                    source={item.iconSource}
+                                    description={item.description}
+                                    ref={lazyRootRef}
+                                />
                             </div>
                         )}
                         {item.name}

--- a/components/menu/menu.jsx
+++ b/components/menu/menu.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import {
     KBarProvider,
     KBarPortal,
@@ -37,15 +37,19 @@ const Menu = ({ children }) => {
         id,
         name,
         keywords: id,
-        icon: (
-            <Image
-                src={`/social/${id}.svg`}
-                width={16}
-                height={16}
-                quality={100}
-                alt=""
-            />
-        ),
+        icon: forwardRef(function renderIcon(props, ref) {
+            return (
+                <Image
+                    {...props}
+                    src={`/social/${id}.svg`}
+                    lazyRoot={ref}
+                    width={16}
+                    height={16}
+                    quality={100}
+                    alt={id}
+                />
+            );
+        }),
         section: 'Social',
         perform: () => window.open(url, '_blank'),
     }));
@@ -145,6 +149,7 @@ const Menu = ({ children }) => {
 
 function RenderResults() {
     const { results } = useMatches();
+    const lazyRootRef = useRef(null);
 
     return (
         <KBarResults
@@ -156,6 +161,7 @@ function RenderResults() {
                     </div>
                 ) : (
                     <div
+                        ref={lazyRootRef}
                         className={`flex items-center cursor-pointer px-4 py-2 ${
                             active
                                 ? 'bg-slate-100 dark:bg-slate-700'
@@ -163,7 +169,9 @@ function RenderResults() {
                         }`}
                     >
                         {item.icon && (
-                            <div className="mr-3 flex">{item.icon}</div>
+                            <div className="mr-3 flex">
+                                <item.icon lazyRoot={lazyRootRef} />
+                            </div>
                         )}
                         {item.name}
                         {item.shortcut && (

--- a/components/menu/menuIcon.jsx
+++ b/components/menu/menuIcon.jsx
@@ -1,0 +1,20 @@
+import React, { forwardRef } from 'react';
+import Image from 'next/image';
+
+const MenuIcon = forwardRef(function renderIcon(props, ref) {
+    const { source, description } = props;
+
+    return (
+        <Image
+            {...props}
+            src={source}
+            lazyRoot={ref}
+            width={16}
+            height={16}
+            quality={100}
+            alt={description}
+        />
+    );
+});
+
+export default MenuIcon;


### PR DESCRIPTION
Prevent the apparition of images when scrolling